### PR TITLE
derived Clone on BehaveTree & BehaveNode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ impl Behave {
 
 /// A state wraps the behaviour, and is the node in our internal tree representation of the behaviour tree
 /// One per Behave, with extra state bits.
-// #[derive(Debug)]
+#[derive(Clone)]
 pub(crate) enum BehaveNode {
     Forever {
         status: Option<BehaveNodeStatus>,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -117,7 +117,7 @@ fn tick_trees(
 /// The main behaviour tree component.
 /// A `bevy_behave` system will query all entities with a `BehaveTree` to tick them.
 /// (unless they have a `BehaveAwaitingTrigger` component)
-#[derive(Component)]
+#[derive(Component, Clone)]
 #[require(BehaveTargetEntity)]
 #[require(Name(||Name::new("BehaveTree")))]
 pub struct BehaveTree {


### PR DESCRIPTION
Adding Clone to BehaveTree & BehaveNode allows for nesting BehaveTrees::new in Behave::Spawn. ex)
`
 Behave::spawn((BehaveTree::new(tree)))
`
